### PR TITLE
feat: add the possibility for a custom login server

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,7 +109,7 @@ resource "aws_ecs_task_definition" "default" {
           },
           {
             name  = "TS_EXTRA_ARGS"
-            value = "--hostname ${var.name}"
+            value = "--hostname ${var.name} --login-server ${var.tailscale_login_server}"
           },
           {
             name  = "TS_TAILSCALED_EXTRA_ARGS",

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "tailscale_version" {
   default     = "1.44.0"
 }
 
+variable "tailscale_login_server" {
+  type        = string
+  description = "Tailscale login server (for instance, a headscale server)"
+  default     = "https://controlplane.tailscale.com"
+}
+
 variable "vpc_id" {
   type        = string
   description = "id of the VPC to launch the router in"


### PR DESCRIPTION
The protocol for tailscale is open, and it is possible to run your own tailscale control plane (such as [headscale](https://github.com/juanfont/headscale)). This PR adds the possibility to configure a custom login server for the router.